### PR TITLE
Add support for new cask repos patch and beta

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_BIN: "dev"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Gemfile.lock
 /pkg
 .rspec_status
 coverage
+dev
+*.gem

--- a/bin/unity-version-manager
+++ b/bin/unity-version-manager
@@ -18,7 +18,7 @@ Usage:
   #{command_name} clear
   #{command_name} detect
   #{command_name} launch [<project-path>] [<platform>]
-  #{command_name} versions
+  #{command_name} versions ([--beta] | [--patch] | [-a |--all])
   #{command_name} version
   #{command_name} (-h | --help)
   #{command_name} --version

--- a/bin/uvm
+++ b/bin/uvm
@@ -18,11 +18,11 @@ Usage:
   #{command_name} clear
   #{command_name} detect
   #{command_name} launch [<project-path>] [<platform>]
-  #{command_name} versions
+  #{command_name} versions (([--beta] [--patch]) | [-a |--all])
   #{command_name} version
   #{command_name} (-h | --help)
   #{command_name} --version
-  
+
 Options:
 --version         print version
 -h, --help        show this help message and exit

--- a/lib/uvm.rb
+++ b/lib/uvm.rb
@@ -84,7 +84,13 @@ module Uvm
     end
 
     def dispatch_versions
-      l = @version_manager.versions
+      o = {
+        beta: @options['--beta'],
+        patch: @options['--patch'],
+        all: @options['--all']  
+      }
+
+      l = @version_manager.versions **o
       i = @version_manager.list mark_active:false
       l = l - i
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 require "simplecov"
-
+require "rspec"
 SimpleCov.start do
   add_filter "/spec/"
 end
@@ -96,4 +96,28 @@ RSpec.shared_context "mock a side unity" do
     end
     version
   }
+end
+
+RSpec::Matchers.define :be_a_unity_version do
+  match do |actual|
+    /(\d+\.\d+\.\d+((f|p|b)\d+)?)$/.match(actual)
+  end
+end
+
+RSpec::Matchers.define :be_a_beta_version do
+  match do |actual|
+    actual.include?('b')
+  end
+end
+
+RSpec::Matchers.define :be_a_patch_version do
+  match do |actual|
+    actual.include?('p')
+  end
+end
+
+RSpec::Matchers.define :be_a_release_version do
+  match do |actual|
+    actual.include?('f')
+  end
 end

--- a/uvm.gemspec
+++ b/uvm.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "docopt", "~> 0.5"
 
   gem.add_development_dependency "bundler", "~> 1.10"
+  gem.add_development_dependency "autotest", "~> 4.4"
   gem.add_development_dependency "rake", "~> 10.0"
   gem.add_development_dependency "ZenTest", "~> 4.11"
   gem.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
## Description
The cask tap [wooga/unityversions](https://github.com/wooga/homebrew-unityversions) no longer contains beta and patch releases. These versions are now included in the new taps:
- [wooga/unityversions-beta](https://github.com/wooga/homebrew-unityversions-beta)
- [wooga/unityversions-patch](https://github.com/wooga/homebrew-unityversions-patch)

This pull request adds support for these new taps and also gives the `#versions` command some filter flags:

```
$uvm versions ([--beta] | [--patch] | [-a |--all])
```

## Changes
![IMPROVE] `versions` command with filter flags
![ADD] support for new brew cask taps

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"