### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _install with brew_
 
 ```bash
 brew tap wooga/tools
-brew install wooga/unity-version-manager
+brew install unity-version-manager
 ```
 
 ## Usage


### PR DESCRIPTION
Current install guide don't work.
=> brew install wooga/unity-version-manager
Error: No available formula with the name "wooga/unity-version-manager"
==> Searching for a previously deleted formula...
Warning: homebrew/core is shallow clone. To get complete history run:
git -C "$(brew --repo homebrew/core)" fetch --unshallow
Error: No previously deleted formula found.
==> Searching for similarly named formulae...
==> Searching local taps...
Error: No similarly named formulae found.

Below fixed guide do work.
brew install unity-version-manager
Updating Homebrew...
==> Installing unity-version-manager from wooga/tools
==> Downloading https://github.com/wooga/unity-version-manager/archive/1.3.0.tar.gz
==> Downloading from https://codeload.github.com/wooga/unity-version-manager/tar.gz/1.3.0
######################################################################## 100.0%
==> Downloading https://rubygems.org/gems/docopt-0.5.0.gem
######################################################################## 100.0%
==> gem install /Users/jcw0913/Library/Caches/Homebrew/unity-version-manager--docopt-0.5.0.gem --no-
==> Downloading https://rubygems.org/gems/plist-3.2.0.gem
######################################################################## 100.0%
==> gem install /Users/jcw0913/Library/Caches/Homebrew/unity-version-manager--plist-3.2.0.gem --no-d
==> gem build uvm.gemspec
==> gem install wooga_uvm-1.3.0.gem
🍺 /usr/local/Cellar/unity-version-manager/1.3.0: 113 files, 275.6KB, built in 11 seconds